### PR TITLE
Upgrade to Objection v1 and remove deprecations

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
 
         if (modelClass.softDelete) {
           this.onBuild(q => {
-            if (q.isFindQuery() && !q.context().includeDeleted) {
+            if (q.isFind() && !q.context().includeDeleted) {
               q.whereNull(`${modelClass.tableName}.${deleteAttr}`);
             }
           });

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "knex": "^0.12.6",
     "mysql": "^2.13.0",
     "nyc": "^10.1.2",
-    "objection": "^0.7.0"
+    "objection": ">=1"
   },
   "peerDependencies": {
-    "objection": "*"
+    "objection": ">=1"
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
Objection has deprecated "isFindQuery" in version 1 and replaced it with "isFind". The functionality has not changed, so a simple change will make this compatible again.

This is not backwards compatible, so we will need a new major version.