### PR TITLE
Fixed delete filter on relatedQuery with alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
         if (modelClass.softDelete) {
           this.onBuild(q => {
             if (q.isFind() && !q.context().includeDeleted) {
-              q.whereNull(`${modelClass.tableName}.${deleteAttr}`);
+              q.whereNull(`${q.tableRefFor(modelClass)}.${deleteAttr}`);
             }
           });
         }


### PR DESCRIPTION
Hi @ackerdev! how are you?

There was a release in objection to fix the missing alias on relatedQueries but this was a breaking change for this kind of plugins that is using tableName to generate the where filter.

Instead of using tableName we can use tableRefFor.

https://github.com/Vincit/objection.js/issues/859